### PR TITLE
Fix KeyError: 'messages'

### DIFF
--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -504,6 +504,7 @@ class Recording:
         with sync_messagefile.open("r") as fh:
             info['_processor_sample_rates'] = []
             info['_processor_start_frames'] = []
+            info['messages'] = []
             info['_software_sample_rate'] = None
             info['_software_start_frame'] = None
             while True:


### PR DESCRIPTION
The else clause here: https://github.com/CINPLA/pyopenephys/blob/c64c7c61fa79cff61cf8ae4c5c69b55c9e1b185a/pyopenephys/core.py#L528 will always fail at https://github.com/CINPLA/pyopenephys/blob/c64c7c61fa79cff61cf8ae4c5c69b55c9e1b185a/pyopenephys/core.py#L531 because `'messages'` is not initialized as an empty list. fixed by doing so.