### PR TITLE
Error specificity when checking for continuous.dat

### DIFF
--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -820,6 +820,8 @@ class Recording:
                                     gains=gains,
                                     sample_rate=sample_rate
                                 ))
+                            elif: len(datfiles) > 1:
+                                raise ValueError("Multiple '.dat' files in folder, expected 1")
                             else:
                                 raise ValueError("'continuous.dat' should be in the folder")
                     else:


### PR DESCRIPTION
Added an additional ValueError for the event that `_read_analog_signals` finds multiple .dat files.
Future edits code could optionally default to using the one that contained 'continuous' in the filename. 
Found a need for this in my own case where user stored another dat file in the same place.