### PR TITLE
Additional file loading checks and timeseries warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.idea/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -163,7 +163,8 @@ class File:
         elif list(Path(self._absolute_foldername).rglob('structure.oebin')):
             # 'binary' format could also be detected with the existence of `structure.oebin` and `continuous` folder under recordings
             oebin_files = list(Path(self._absolute_foldername).rglob('structure.oebin'))
-            assert np.all([(oebin_file.parent / 'continuous').exists() for oebin_file in oebin_files])
+            if not np.all([(oebin_file.parent / 'continuous').exists() for oebin_file in oebin_files]):
+                raise FileNotFoundError(f"Could not find paired 'continuous' file for each oebin in {oebin_file.parent}")
 
             self.format = 'binary'
             experiments_names = sorted(set([oebin_file.parent.parent.name for oebin_file in oebin_files]))
@@ -1125,5 +1126,6 @@ def _load_timestamps(ts_npy_file, sample_rate):
         return ts / sample_rate
 
     fs = 1/period
-    assert np.isclose(sample_rate, fs, rtol=3e-4), f'Error loading timestamps ({ts_npy_file})\nSignificant discrepancy found in the provided sample rate ({sample_rate}) and that computed from the data ({fs})'
+    if not np.isclose(sample_rate, fs, rtol=3e-4):
+        warnings.warn(f'Error loading timestamps ({ts_npy_file})\nSignificant discrepancy found in the provided sample rate ({sample_rate}) and that computed from the data ({fs})')
     return ts

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -839,7 +839,7 @@ class Recording:
                                 ts = _load_timestamps(data_folder / 'timestamps.npy', sample_rate)
                                 self._start_times.append(ts[0] * pq.s)
                                 if len(ts) != nsamples:
-                                    warnings.warn('timestamps and nsamples are different!')
+                                    warnings.warn('timestamps and nsamples are different ({})!'.format(data_folder))
                                     ts = np.arange(nsamples) / sample_rate
                                 else:
                                     ts -= ts[0]

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -832,7 +832,7 @@ class Recording:
                             data_folder = self._continuous_folder / cont["folder_name"]
                             nchan = cont["num_channels"]
                             sample_rate = cont["sample_rate"]
-                            datfiles = [f for f in data_folder.iterdir() if f.suffix == '.dat']
+                            datfiles = [f for f in data_folder.iterdir() if f.name == 'continuous.dat']
 
                             if len(datfiles) == 1:
                                 datfile = datfiles[0]

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -400,7 +400,7 @@ class Recording:
                     with oebin_files[0].open('r') as f:
                         self._oebin = json.load(f)
                 elif len(oebin_files) == 0:
-                    raise FileNotFoundError("'structre.oebin' file not found! Impossible to retrieve configuration "
+                    raise FileNotFoundError(f"'structure.oebin' file not found in ({self.absolute_foldername})! Impossible to retrieve configuration "
                                             "information")
                 else:
                     raise Exception("Multiple oebin files found. Impossible to retrieve configuration information")
@@ -1113,7 +1113,12 @@ def _load_timestamps(ts_npy_file, sample_rate):
     if ts.dtype == np.int32 or ts.dtype == np.int64:
         return ts / sample_rate
 
-    period = np.median(np.diff(ts))
+    ts_diff = np.diff(ts)
+    if any(ts_diff <= 0):
+        warnings.warn('Loaded timestamps ({}) not monotonically increasing - constructing timestamps from sample rate instead!'.format(ts_npy_file))
+        return np.arange(len(ts)) / sample_rate
+
+    period = np.median(ts_diff)
     if period == 1:
         return ts / sample_rate
 

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -258,14 +258,16 @@ class Experiment:
                          if fname.startswith('settings') and fname.endswith('.xml') and str(id) in fname]
 
         if not len(set_fname) == 1:
-            # raise IOError('Unique settings file not found')
-            print("settings.xml not found. Can't load signal chain information")
-            self._set_fname = None
-            self.sig_chain = None
-            self.setting = None
-            self.format = None
-            self.nchan = None
-            self._start_datetime = datetime(1970, 1, 1)
+            if self.file.format == 'binary':
+                raise IOError(f'Unique settings file not found in {self._path}')
+            else:
+                print("settings.xml not found. Can't load signal chain information")
+                self._set_fname = None
+                self.sig_chain = None
+                self.setting = None
+                self.format = None
+                self.nchan = None
+                self._start_datetime = datetime(1970, 1, 1)
         else:
             self._set_fname = op.join(self._path, set_fname[0])
             with open(self._set_fname) as f:

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -1118,5 +1118,5 @@ def _load_timestamps(ts_npy_file, sample_rate):
         return ts / sample_rate
 
     fs = 1/period
-    assert np.isclose(sample_rate, fs, rtol=1e-4), f'Significant discrepancy found in the provided sample rate ({sample_rate}) and that computed from the data ({fs})'
+    assert np.isclose(sample_rate, fs, rtol=3e-4), f'Error loading timestamps ({ts_npy_file})\nSignificant discrepancy found in the provided sample rate ({sample_rate}) and that computed from the data ({fs})'
     return ts

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -545,7 +545,12 @@ class Recording:
         stimes = []
 
         if self.format == 'binary':
-            sync_messagefile = [f for f in self.absolute_foldername.iterdir() if 'sync_messages' in f.name][0]
+            sync_messagefile = [f for f in self.absolute_foldername.iterdir() if 'sync_messages' in f.name]
+            if sync_messagefile:
+                sync_messagefile = sync_messagefile[0]
+            else:
+                warnings.warn(f'No "sync_messages" file found for binary format in {self.absolute_foldername}')
+                return info
         elif self.format == 'openephys':
             if self.experiment.id == 1:
                 sync_messagefile = self.absolute_foldername / 'messages.events'

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -1110,7 +1110,7 @@ def _load_timestamps(ts_npy_file, sample_rate):
     """
     ts = np.load(ts_npy_file)
 
-    if isinstance(ts.dtype, int):
+    if ts.dtype == np.int32 or ts.dtype == np.int64:
         return ts / sample_rate
 
     period = np.median(np.diff(ts))

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -295,7 +295,11 @@ class Experiment:
                 else:
                     processor_iter = [sigchain['PROCESSOR']]
                 for processor in processor_iter:
-                    self.sig_chain.update({processor['@name']: processor['@NodeId']})
+                    processor_node_id = processor.get("@nodeId", processor.get("@NodeId"))
+                    if processor_node_id is None:
+                        raise KeyError('Neither "@nodeId" nor "@NodeId" key found')
+
+                    self.sig_chain.update({processor['@name']: processor_node_id})
                     if is_v4:
                         is_source = 'CHANNEL_INFO' in processor.keys() and processor['@isSource'] == '1'
                         is_source_alt = 'CHANNEL' in processor.keys() and processor['@isSource'] == '1'

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -272,7 +272,7 @@ class Experiment:
                 xmldata = f.read()
                 self.settings = xmltodict.parse(xmldata)['SETTINGS']
             is_v4 = LooseVersion(self.settings['INFO']['VERSION']) >= LooseVersion('0.4.0.0')
-            is_v6 = LooseVersion(self.experiment.settings['INFO']['VERSION']) >= LooseVersion('0.6.0')
+            is_v6 = LooseVersion(self.settings['INFO']['VERSION']) >= LooseVersion('0.6.0')
             # read date in US format
             if platform.system() == 'Windows':
                 locale.setlocale(locale.LC_ALL, 'english')

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -340,7 +340,7 @@ class Experiment:
                 recorder = self.settings['RECORDENGINES']['ENGINE'][recorder_idx]['@id']
             if recorder == 'OPENEPHYS':
                 self.format = 'openephys'
-            elif recorder == 'RAWBINARY':
+            elif recorder in ('BINARY', 'RAWBINARY'):
                 self.format = 'binary'
             else:
                 self.format = None

--- a/pyopenephys/core.py
+++ b/pyopenephys/core.py
@@ -1127,5 +1127,5 @@ def _load_timestamps(ts_npy_file, sample_rate):
 
     fs = 1/period
     if not np.isclose(sample_rate, fs, rtol=3e-4):
-        warnings.warn(f'Error loading timestamps ({ts_npy_file})\nSignificant discrepancy found in the provided sample rate ({sample_rate}) and that computed from the data ({fs})')
+        raise ValueError(f'Error loading timestamps ({ts_npy_file})\nSignificant discrepancy found in the provided sample rate ({sample_rate}) and that computed from the data ({fs})')
     return ts

--- a/pyopenephys/version.py
+++ b/pyopenephys/version.py
@@ -1,1 +1,1 @@
-version = '1.1.5'
+version = '1.1.6'


### PR DESCRIPTION
In this PR, our team proposes the following changes...
- Recursive search on the provided folder for `structure.oebin` and `continuous` files.
- Checking for the presence of `settings.xml` before reading settings.
- Within `_read_settings`, introducing the commented out `IOError` when for binary formats.
- Added handling for the new folder/file naming convention in the new Open Ephys format (0.6.0), while maintaining backward compatibility
- Return folder name when raising `FileNotFoundError`
- Within `_read_analog_signals`, specify `continuous.dat` when looking for `dat` files
- `_load_timestamps`, which runs checks to ensure timestamps are increasing and the sample is close to the expected value.